### PR TITLE
Add types for public API

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "https://github.com/bigtestjs/convergence",
   "main": "dist/index.js",
   "module": "src/index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "build": "rollup --config",
     "test": "mocha --opts ./tests/mocha.opts ./tests",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/types/converge-on.d.ts
+++ b/types/converge-on.d.ts
@@ -1,0 +1,21 @@
+export interface IStats<T> {
+  start: string;
+  runs: number;
+  end: number;
+  elapsed: number;
+  always: boolean;
+  timeout: number;
+  value: T;
+}
+
+export default convergeOn;
+
+declare function convergeOn<T>(
+  assertion: convergeOn.Assertion<T>,
+  timeout?: number,
+  always?: boolean
+): Promise<IStats<T>>;
+
+declare namespace convergeOn {
+  export type Assertion<T> = () => T;
+}

--- a/types/convergence.d.ts
+++ b/types/convergence.d.ts
@@ -1,0 +1,19 @@
+import { IStats } from './converge-on';
+
+export type Assertion<T, U> = (previous: U) => T;
+
+export type SideEffect<T, U> = (previous: U) => T;
+
+export default Convergence;
+
+declare class Convergence<T> {
+  constructor(timeout?: number);
+  timeout(timeout: number): Convergence<T>;
+  timeout(): number;
+  when<U>(assertion: Assertion<U, T>): Convergence<U>;
+  once<U>(assertion: Assertion<U, T>): Convergence<U>;
+  always<U>(assertion: Assertion<U, T>, timeout: number): Convergence<U>;
+  do<U>(callback: SideEffect<U, T>): Convergence<U>;
+  append<U>(convergence: Convergence<U>): Convergence<U>;
+  run(): Promise<IStats<T>>;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,3 @@
+export { default as convergeOn, IStats } from './converge-on';
+export { isConvergence } from './utils';
+export { default, Assertion, SideEffect } from './convergence';

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -1,0 +1,4 @@
+import convergeOn from './converge-on';
+import Convergence from './convergence';
+
+export declare function isConvergence(obj: any): obj is Convergence;


### PR DESCRIPTION
So that BigTest can be used in TS projects. The `tsconfig.json` is for IntelliSense which aids in the creation/maintenance of the type declaration files.

This exports the `IStats` interface and `Assertion` and `SideEffect` function types from the `index.d.ts` file since those are public APIs. `SideEffect` is the type signature for the callback passed to `Convergence#do()` and I thought it was odd that `#do()`, although intended for side-effects, can perform side-effects _and_ passes on the return value in the new `Convergence` it returns—unless I misinterpreted what's going on. I would have expected it to only perform side effects and for anything returned from its callback to be swallowed. If both behaviors are desired maybe that indicates an additional method like `#map()`?