### PR TITLE
Change `_timeout` to `timeout` in constructor options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- `_timeout` to `timeout` when providing an options hash to the
+  convergence constructor
+
 ## [0.7.0] - 2018-04-07
 
 ### Added

--- a/src/convergence.js
+++ b/src/convergence.js
@@ -95,11 +95,11 @@ class Convergence {
   constructor(options = {}, previous = {}) {
     // a timeout was given
     if (typeof options === 'number') {
-      options = { _timeout: options };
+      options = { timeout: options };
     }
 
     let {
-      _timeout = previous._timeout || 2000,
+      timeout = previous._timeout || 2000,
       _stack = []
     } = options;
 
@@ -107,7 +107,7 @@ class Convergence {
     _stack = [...(previous._stack || []), ..._stack];
 
     Object.defineProperties(this, {
-      _timeout: { value: _timeout },
+      _timeout: { value: timeout },
       _stack: { value: _stack }
     });
   }


### PR DESCRIPTION
## Purpose 

The public API for Convergence is `new Convergence(timeout)`. But internally, it is `new Convergence(options, previous)`. This is so other classes such as `Interactor` from `@bigtest/interactor` can extend Convergence and provide their own constructor args.

It would be helpful if extended convergences can also provide an initial timeout without having to call `#timeout` explicitly. The internal option is `_timeout`, but by removing the underscore it can be documented as a public option for extended classes.

```js
new Interactor({
  scope: '.some-selector',
  timeout: 1000
})
```

## Approach

Just rename `_timeout` to `timeout` in the constructor.