### PR TITLE
Change "stack" terminology to "queue"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ within a single timeout period.
 ``` javascript
 import Convergence from '@bigtest/convergence'
 
-// starts a new stack
+// starts a new queue
 new Convergence()
-  // adds a convergent function to the stack
+  // adds a convergent function to the queue
   .when(() => expect($el).to.exist)
   // called when the previous function converges
   .do(() => $el.get(0).click())
@@ -139,7 +139,7 @@ convergeLong.timeout(); // => 5000
 **`.when(assert)`**
 
 Returns a new `Convergence` instance and adds the provided assertion
-to its stack. When this instance is ran, the `assert` function will be
+to its queue. When this instance is ran, the `assert` function will be
 looped over repeatedly until it passes, or until the convergence's
 timeout has been exceeded.
 
@@ -164,9 +164,9 @@ or never fails for the duration of the timeout.
 converge.always(() => total === 5)
 ```
 
-When a convergence added with `.always()` is last in the stack, it
+When a convergence added with `.always()` is last in the queue, it
 will be given the remaining total timeout to converge on its assertion
-always passing. When it _is not_ last in the stack, `timeout` is used
+always passing. When it _is not_ last in the queue, `timeout` is used
 instead. By default, `timeout` will be a tenth of the total timeout
 or `20ms` (whichever is greater).
 
@@ -183,14 +183,14 @@ converge
 new Convergence(2000)
   // defaults to 200ms
   .always(() => total === 5)
-  // this counts as part of the stack
+  // this counts as part of the queue
   .do(() => console.log(total))
 ```
 
 **`.do(exec)`**
 
 This method is useful when you need to execute something after a
-convergence in the stack, but before other convergences are ran.
+convergence in the queue, but before other convergences are ran.
 This can help with debugging in between convergences and also
 allows you to run side effects between convergences.
 
@@ -203,10 +203,10 @@ converge
   .always(() => total === 500)
 ```
 
-Functions in a `Convergence` stack curry their return value
-between other functions in the stack. This means that what you return
-from one function in the stack will be available as the argument
-given to the next function in the stack.
+Functions in a `Convergence` queue curry their return value
+between other functions in the queue. This means that what you return
+from one function in the queue will be available as the argument
+given to the next function in the queue.
 
 ``` javascript
 converge
@@ -258,8 +258,8 @@ converge1.append(converge5)
 In order to actually run a `Convergence` instance, you must call the
 `.run()` method. This method **does not return another instance**,
 instead it returns a promise that resolves when all assertions in the
-stack have converged. The returned promise will keep track of the
-current timeout and ensure that all convergences in the stack converge
+queue have converged. The returned promise will keep track of the
+current timeout and ensure that all convergences in the queue converge
 within that period.
 
 Because `.run()` returns a promise, and `Convergence` is immutable,
@@ -278,27 +278,27 @@ converge.run()
 
 The promise returned from `.run()` resolves with a stats object. This
 stats object holds various information about how the convergences in
-the stack ran. The `stack` property is an array of stats objects
-specific to each function in the stack.
+the queue ran. The `queue` property is an array of stats objects
+specific to each function in the queue.
 
 ``` javascript
 converge.run((stats) => {
   stats.start    // start time of the convergences
   stats.end      // end time of the convergences
-  stats.elapsed  // time taken to converge on the entire stack
-  stats.runs     // number of times functions in the stack ran
+  stats.elapsed  // time taken to converge on the entire queue
+  stats.runs     // number of times functions in the queue ran
   stats.timeout  // this Convergence instance's timeout
-  stats.value    // value returned from the last function in the stack
-  stats.stack    // an array of stats objects from the stack
+  stats.value    // value returned from the last function in the queue
+  stats.queue    // an array of stats objects from the queue
 
-  // each function in the stack produces similar stats objects
-  stats.stack[0].start    // start time of this convergence
-  stats.stack[0].end      // end time of this convergence
-  stats.stack[0].elapsed  // time taken for this convergence
-  stats.stack[0].runs     // number of times this convergence ran
-  stats.stack[0].timeout  // the timeout this convergence was given
-  stats.stack[0].always   // whether this convergence used .always()
-  stats.stack[0].value    // value returned from this convergence
+  // each function in the queue produces similar stats objects
+  stats.queue[0].start    // start time of this convergence
+  stats.queue[0].end      // end time of this convergence
+  stats.queue[0].elapsed  // time taken for this convergence
+  stats.queue[0].runs     // number of times this convergence ran
+  stats.queue[0].timeout  // the timeout this convergence was given
+  stats.queue[0].always   // whether this convergence used .always()
+  stats.queue[0].value    // value returned from this convergence
 });
 ```
 

--- a/src/convergence.js
+++ b/src/convergence.js
@@ -100,15 +100,15 @@ class Convergence {
 
     let {
       timeout = previous._timeout || 2000,
-      _stack = []
+      _queue = []
     } = options;
 
-    // merge with the previous stack, if given
-    _stack = [...(previous._stack || []), ..._stack];
+    // merge with the previous queue, if given
+    _queue = [...(previous._queue || []), ..._queue];
 
     Object.defineProperties(this, {
       _timeout: { value: timeout },
-      _stack: { value: _stack }
+      _queue: { value: _queue }
     });
   }
 
@@ -156,7 +156,7 @@ class Convergence {
    */
   when(assertion) {
     return new this.constructor({
-      _stack: [{ assertion }]
+      _queue: [{ assertion }]
     }, this);
   }
 
@@ -203,7 +203,7 @@ class Convergence {
    */
   always(assertion, timeout) {
     return new this.constructor({
-      _stack: [{
+      _queue: [{
         always: true,
         assertion,
         timeout
@@ -213,10 +213,10 @@ class Convergence {
 
   /**
    * Returns a new convergence instance with a callback added to its
-   * stack. When a running convergence instance encounters a callback,
+   * queue. When a running convergence instance encounters a callback,
    * it will be invoked with the value returned from the last function
-   * in the stack. The resulting return value will also be provided to
-   * the following function in the stack.
+   * in the queue. The resulting return value will also be provided to
+   * the following function in the queue.
    *
    * ``` javascript
    * new Convergence()
@@ -277,12 +277,12 @@ class Convergence {
    */
   do(callback) {
     return new this.constructor({
-      _stack: [{ callback }]
+      _queue: [{ callback }]
     }, this);
   }
 
   /**
-   * Appends another convergence's stack to this convergence's stack
+   * Appends another convergence's queue to this convergence's queue
    * to allow composing different convergences together.
    *
    * ``` javascript
@@ -305,7 +305,7 @@ class Convergence {
     }
 
     return new this.constructor({
-      _stack: convergence._stack
+      _queue: convergence._queue
     }, this);
   }
 
@@ -351,8 +351,8 @@ class Convergence {
    *   stats.elapsed // amount of milliseconds the convergence took
    *   stats.timeout // the timeout this convergence used
    *   stats.runs    // total times this convergence ran an assertion
-   *   stats.value   // last returned value from the stack
-   *   stats.stack   // array of other stats for each assertion
+   *   stats.value   // last returned value from the queue
+   *   stats.queue   // array of other stats for each assertion
    * })
    * ```
    *
@@ -368,13 +368,13 @@ class Convergence {
       elapsed: 0,
       value: undefined,
       timeout: this._timeout,
-      stack: []
+      queue: []
     };
 
-    // reduce to a single promise that runs each item in the stack
-    return this._stack.reduce((promise, subject, i) => {
+    // reduce to a single promise that runs each item in the queue
+    return this._queue.reduce((promise, subject, i) => {
       // the last subject will receive the remaining timeout
-      if (i === (this._stack.length - 1)) {
+      if (i === (this._queue.length - 1)) {
         subject = Object.assign({ last: true }, subject);
       }
 
@@ -411,7 +411,7 @@ class Convergence {
    *
    * The convergence thennable method immediately invokes `#run()` and
    * resolves with the last returned value from the convergence's
-   * stack. This allows us to await for values from a convergence.
+   * queue. This allows us to await for values from a convergence.
    *
    * ``` javascript
    * let find = (selector) => new Convergence().when(() => {
@@ -429,7 +429,7 @@ class Convergence {
    * @returns {Promise}
    */
   then() {
-    // resolve with the value of the last function in the stack
+    // resolve with the value of the last function in the queue
     let promise = this.run().then(({ value }) => value);
     // pass promise arguments onward
     return promise.then.apply(promise, arguments);

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,7 +34,7 @@ function collectStats(accumulator, stats) {
   accumulator.elapsed += stats.elapsed;
   accumulator.end = stats.end;
   accumulator.value = stats.value;
-  accumulator.stack.push(stats);
+  accumulator.queue.push(stats);
 
   return stats.value;
 }
@@ -60,17 +60,17 @@ function collectStats(accumulator, stats) {
  */
 export function isConvergence(obj) {
   return !!obj && typeof obj === 'object' &&
-    '_stack' in obj && Array.isArray(obj._stack) &&
+    '_queue' in obj && Array.isArray(obj._queue) &&
     'timeout' in obj && typeof obj.timeout === 'function' &&
     'run' in obj && typeof obj.run === 'function';
 }
 
 /**
- * Runs a single assertion from a convergence stack with `arg` as the
+ * Runs a single assertion from a convergence queue with `arg` as the
  * assertion's argument. Adds convergence stats to the `stats` object.
  *
  * @private
- * @param {Object} subject - Convergence assertion stack item
+ * @param {Object} subject - Convergence assertion queue item
  * @param {*} arg - Passed as the assertion's argument
  * @param {Object} stats - Stats accumulator object
  * @returns {Promise} Resolves with the assertion's return value
@@ -96,7 +96,7 @@ export function runAssertion(subject, arg, stats) {
 }
 
 /**
- * Runs a single function from a convergence stack with `arg` as the
+ * Runs a single function from a convergence queue with `arg` as the
  * function's argument. Adds simple stats to the `stats` object.
  *
  * When a promise is returned, the time it takes to resolve is
@@ -107,7 +107,7 @@ export function runAssertion(subject, arg, stats) {
  * is curried on.
  *
  * @private
- * @param {Object} subject - Convergence exec stack item
+ * @param {Object} subject - Convergence exec queue item
  * @param {*} arg - Passed as the function's argument
  * @param {Object} stats - Stats accumulator object
  * @returns {Promise} Resolves with the function's return value

--- a/tests/convergence-test.js
+++ b/tests/convergence-test.js
@@ -534,6 +534,17 @@ describe('BigTest Convergence', () => {
         expect(stats.value).to.equal(50);
         expect(stats.queue).to.have.lengthOf(4);
       });
+
+      it('stores and calls the callbacks first-in-first-out', async () => {
+        let arr = [];
+
+        let assertion = converge
+          .do(() => arr.push('first'))
+          .do(() => arr.push('second'));
+
+        await expect(assertion.run()).to.be.fulfilled;
+        expect(arr).to.deep.equal(['first', 'second']);
+      });
     });
   });
 });

--- a/tests/convergence-test.js
+++ b/tests/convergence-test.js
@@ -121,17 +121,17 @@ describe('BigTest Convergence', () => {
         expect(assertion).to.not.equal(converge);
       });
 
-      it('creates a new stack', () => {
-        expect(assertion._stack).to.not.equal(converge._stack);
-        expect(assertion._stack).to.have.lengthOf(1);
-        expect(converge._stack).to.have.lengthOf(0);
+      it('creates a new queue', () => {
+        expect(assertion._queue).to.not.equal(converge._queue);
+        expect(assertion._queue).to.have.lengthOf(1);
+        expect(converge._queue).to.have.lengthOf(0);
       });
 
-      it('adds the assertion to the new stack', () => {
+      it('adds the assertion to the new queue', () => {
         let assert = () => {};
 
         assertion = assertion.when(assert);
-        expect(assertion._stack[1]).to.have.property('assertion', assert);
+        expect(assertion._queue[1]).to.have.property('assertion', assert);
       });
     });
 
@@ -147,19 +147,19 @@ describe('BigTest Convergence', () => {
         expect(assertion).to.not.equal(converge);
       });
 
-      it('creates a new stack', () => {
-        expect(assertion._stack).to.not.equal(converge._stack);
-        expect(assertion._stack).to.have.lengthOf(1);
-        expect(converge._stack).to.have.lengthOf(0);
+      it('creates a new queue', () => {
+        expect(assertion._queue).to.not.equal(converge._queue);
+        expect(assertion._queue).to.have.lengthOf(1);
+        expect(converge._queue).to.have.lengthOf(0);
       });
 
-      it('adds to a new stack with an `always` flag and own timeout', () => {
+      it('adds to a new queue with an `always` flag and own timeout', () => {
         let assert = () => {};
 
         assertion = assertion.always(assert, 200);
-        expect(assertion._stack[1]).to.have.property('assertion', assert);
-        expect(assertion._stack[1]).to.have.property('always', true);
-        expect(assertion._stack[1]).to.have.property('timeout', 200);
+        expect(assertion._queue[1]).to.have.property('assertion', assert);
+        expect(assertion._queue[1]).to.have.property('always', true);
+        expect(assertion._queue[1]).to.have.property('timeout', 200);
       });
     });
 
@@ -175,17 +175,17 @@ describe('BigTest Convergence', () => {
         expect(callback).to.not.equal(converge);
       });
 
-      it('creates a new stack', () => {
-        expect(callback._stack).to.not.equal(converge._stack);
-        expect(callback._stack).to.have.lengthOf(1);
-        expect(converge._stack).to.have.lengthOf(0);
+      it('creates a new queue', () => {
+        expect(callback._queue).to.not.equal(converge._queue);
+        expect(callback._queue).to.have.lengthOf(1);
+        expect(converge._queue).to.have.lengthOf(0);
       });
 
-      it('adds to a new stack with an `exec` property', () => {
+      it('adds to a new queue with an `exec` property', () => {
         let fn = () => {};
 
         callback = callback.do(fn);
-        expect(callback._stack[1]).to.have.property('callback', fn);
+        expect(callback._queue[1]).to.have.property('callback', fn);
       });
     });
 
@@ -203,20 +203,20 @@ describe('BigTest Convergence', () => {
         expect(combined).to.not.equal(converge);
       });
 
-      it('creates a new stack', () => {
-        expect(combined._stack).to.not.equal(converge._stack);
-        expect(combined._stack).to.have.lengthOf(1);
-        expect(converge._stack).to.have.lengthOf(0);
+      it('creates a new queue', () => {
+        expect(combined._queue).to.not.equal(converge._queue);
+        expect(combined._queue).to.have.lengthOf(1);
+        expect(converge._queue).to.have.lengthOf(0);
       });
 
-      it('combines the two stacks', () => {
+      it('combines the two queues', () => {
         let fn = () => {};
 
         combined = combined.append(
           new Convergence().do(fn)
         );
 
-        expect(combined._stack[1]).to.have.property('callback', fn);
+        expect(combined._queue[1]).to.have.property('callback', fn);
       });
     });
   });
@@ -439,7 +439,7 @@ describe('BigTest Convergence', () => {
 
           converge = converge.do(() => 1);
           return expect(assertion.run()).to.be.fulfilled
-            .and.eventually.have.nested.property('stack[0].value', 1);
+            .and.eventually.have.nested.property('queue[0].value', 1);
         });
 
         it('rejects after the exceeding the timeout', () => {
@@ -488,7 +488,7 @@ describe('BigTest Convergence', () => {
 
           createTimeout(() => resolve(1), 10);
           return expect(assertion.run()).to.be.fulfilled
-            .and.eventually.have.nested.property('stack[0].value', 1);
+            .and.eventually.have.nested.property('queue[0].value', 1);
         });
 
         it('rejects after the exceeding the timeout', () => {
@@ -532,7 +532,7 @@ describe('BigTest Convergence', () => {
         expect(stats.runs).to.be.within(8, 12);
         expect(stats.timeout).to.equal(100);
         expect(stats.value).to.equal(50);
-        expect(stats.stack).to.have.lengthOf(4);
+        expect(stats.queue).to.have.lengthOf(4);
       });
     });
   });


### PR DESCRIPTION
## Purpose

Addresses #9.

The term "queue" more accurately describes the usage of the array in the `Convergence` class used to store callbacks and assertions. We do two things with it: append items to the end and iterate; making it first-in-first-out.

## Approach

Wish I could say that I used `find` and `sed` and so forth but I am not a h4x0r and used VSCode find and replace instead.

I also added a test expressing this aspect of the API.