### PR TITLE
Throw an error when using async functions with convergences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- error when using async functions or returning promises with
+  convergent assertions
+
 ## [0.9.1] - 2018-05-05
 
 ### Changed
@@ -21,7 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
 
 - `when` and `always` helpers to immediately start converging on a
-  single assertion without the need for creating a `Convergence`
+single assertion without the need for creating a `Convergence`
 
 ### Removed
 
@@ -37,7 +42,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - `_timeout` to `timeout` when providing an options hash to the
-  convergence constructor
+convergence constructor
 
 ## [0.7.0] - 2018-04-07
 
@@ -83,7 +88,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - convergent assertions no longer attempt to resolve or reject before
-  their timeout
+their timeout
 
 ## [0.3.0] - 2018-02-18
 
@@ -94,7 +99,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - convergence constructor to be more general to allow subclasses to
-  handle their own construction
+handle their own construction
 
 ## [0.2.0] - 2018-02-16
 
@@ -103,7 +108,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - `.append()` method to combine convergences together
 
 - "module" entry point to support native consumption of @bigtest/mocha
-  as es module
+as es module
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.10.0] - 2018-07-05
+
 ### Added
 
 - error when using async functions or returning promises with

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/convergence",
   "description": "Convergence helpers for testing big",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/convergence",
   "main": "dist/umd/index.js",

--- a/src/converge.js
+++ b/src/converge.js
@@ -43,6 +43,15 @@ export function convergeOn(assertion, timeout, always) {
       try {
         let results = assertion();
 
+        // a promise means there could be side-effects
+        if (results && typeof results.then === 'function') {
+          throw new Error(
+            'convergent assertion encountered a async function or promise; ' +
+            'since convergent assertions can run multiple times, you should ' +
+            'avoid introducing side-effects inside of them'
+          );
+        }
+
         // the timeout calculation comes after the assertion so that
         // the assertion's execution time is accounted for
         let doLoop = Date.now() - start < timeout;

--- a/tests/converge-always-test.js
+++ b/tests/converge-always-test.js
@@ -35,6 +35,14 @@ describe('BigTest Convergence - always', () => {
     expect(Date.now() - start).to.be.within(30, 50);
   });
 
+  it('rejects with an error when using an async function', () => {
+    expect(always(async () => {})).to.be.rejectedWith(/async/);
+  });
+
+  it('rejects with an error when returning a promise', () => {
+    expect(always(() => Promise.resolve())).to.be.rejectedWith(/promise/);
+  });
+
   it('resolves with a stats object', async () => {
     let start = Date.now();
     let stats = await expect(test(5)).to.be.fulfilled;

--- a/tests/converge-when-test.js
+++ b/tests/converge-when-test.js
@@ -44,6 +44,14 @@ describe('BigTest Convergence - when', () => {
     expect(Date.now() - start).to.be.within(50, 70);
   });
 
+  it('rejects with an error when using an async function', () => {
+    expect(when(async () => {})).to.be.rejectedWith(/async/);
+  });
+
+  it('rejects with an error when returning a promise', () => {
+    expect(when(() => Promise.resolve())).to.be.rejectedWith(/promise/);
+  });
+
   it('resolves with a stats object', async () => {
     test = (num) => when(() => total === 5 && total * 100);
     timeout = setTimeout(() => total = 5, 30);

--- a/tests/convergence-test.js
+++ b/tests/convergence-test.js
@@ -274,6 +274,14 @@ describe('BigTest Convergence', () => {
         return expect(assertion.run()).to.be.fulfilled;
       });
 
+      it('rejects with an error when using an async function', () => {
+        expect(converge.when(async () => {}).run()).to.be.rejectedWith(/async/);
+      });
+
+      it('rejects with an error when returning a promise', () => {
+        expect(converge.when(() => Promise.resolve()).run()).to.be.rejectedWith(/promise/);
+      });
+
       describe('with additional chaining', () => {
         beforeEach(() => {
           assertion = assertion.when(() => expect(total).to.equal(10));
@@ -326,6 +334,14 @@ describe('BigTest Convergence', () => {
         let start = Date.now();
         await expect(assertion.run()).to.be.rejected;
         expect(Date.now() - start).to.be.within(50, 70);
+      });
+
+      it('rejects with an error when using an async function', () => {
+        expect(converge.always(async () => {}).run()).to.be.rejectedWith(/async/);
+      });
+
+      it('rejects with an error when returning a promise', () => {
+        expect(converge.always(() => Promise.resolve()).run()).to.be.rejectedWith(/promise/);
       });
 
       describe('with additional chaining', () => {


### PR DESCRIPTION
## Purpose

If you use an async function, or return a promise from a convergent assertion, we should throw an error about using side-effects inside convergences.

## Approach

Check if the results of the assertion are thennable, and then throw an error.

### TODOs & Open Questions

- Should we throw a warning or stick with the error? The assertion is run at least once regardless.
- Is this a fix (patch release) or a feature (minor release)?
- [x] Add to the changelog and release a new version pending the above questions
- [ ] Update other convergence based packages `@bigtest/mocha` & `@bigtest/interactor`