### PR TITLE
Immediately throw when encountering an async assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- immediately throw when encountering an async assertion
+
 ## [0.10.0] - 2018-07-05
 
 ### Added

--- a/tests/converge-always-test.js
+++ b/tests/converge-always-test.js
@@ -35,12 +35,12 @@ describe('BigTest Convergence - always', () => {
     expect(Date.now() - start).to.be.within(30, 50);
   });
 
-  it('rejects with an error when using an async function', () => {
-    expect(always(async () => {})).to.be.rejectedWith(/async/);
+  it('rejects with an error when using an async function', async () => {
+    await expect(always(async () => {})).to.be.rejectedWith(/async/);
   });
 
-  it('rejects with an error when returning a promise', () => {
-    expect(always(() => Promise.resolve())).to.be.rejectedWith(/promise/);
+  it('rejects with an error when returning a promise', async () => {
+    await expect(always(() => Promise.resolve())).to.be.rejectedWith(/promise/);
   });
 
   it('resolves with a stats object', async () => {

--- a/tests/converge-when-test.js
+++ b/tests/converge-when-test.js
@@ -44,12 +44,12 @@ describe('BigTest Convergence - when', () => {
     expect(Date.now() - start).to.be.within(50, 70);
   });
 
-  it('rejects with an error when using an async function', () => {
-    expect(when(async () => {})).to.be.rejectedWith(/async/);
+  it('rejects with an error when using an async function', async () => {
+    await expect(when(async () => {})).to.be.rejectedWith(/async/);
   });
 
-  it('rejects with an error when returning a promise', () => {
-    expect(when(() => Promise.resolve())).to.be.rejectedWith(/promise/);
+  it('rejects with an error when returning a promise', async () => {
+    await expect(when(() => Promise.resolve())).to.be.rejectedWith(/promise/);
   });
 
   it('resolves with a stats object', async () => {


### PR DESCRIPTION
## Purpose

I noticed that the tests for this error were async expectations (via chai-as-promised) however the tests themselves were not declared async. 

While this made the tests technically false-positives (they always pass), the actual expectations were successful. However, the errors are thrown after attempting to converge for the entire timeout resulting in mocha throwing timeout errors for those `when` tests.

## Approach

Fixed the tests to be proper async, and added a local `bail` variable that, when `true`, will cause the convergence to fail immediately.