### PR TITLE
Return thennable functions from convergence helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - immediately throw when encountering an async assertion
+- `when` and `always` helpers return thennable functions that can be
+  used as callbacks, or awaited on directly
 
 ## [0.10.0] - 2018-07-05
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,20 @@ await when(() => {
 })
 ```
 
+Returns a thennable function that can both be used as a callback and
+awaited on directly. For example, testing frameworks that support
+async tests work well with convergent assertions.
+
+``` javascript
+test('will eventually become bar within 1s', when(() => {
+  expect(foo).to.equal('bar');
+}, 1000));
+```
+
+_Note: `when` will throw an error **after** it fails to converge
+within the timeout. When using with testing frameworks, be aware of
+any test timeouts that may occur before the convergence fails._
+
 **`always(assertion[, timeout=200])`**
 
 Starts converging on the given `assertion`, resolving when it passes
@@ -365,3 +379,16 @@ await always(() => {
   expect(add(total, 1)).to.equal(101)
 })
 ```
+
+Also returns a thennable function that can both be used as a callback
+and awaited on directly.
+
+``` javascript
+test('remains foo for at least 1s', always(() => {
+  expect(foo).to.equal('foo');
+}, 1000));
+```
+
+_Note: `always` will resolve **after** it converges throughout the
+entire timeout. When using with testing frameworks, be aware of any
+test timeouts that may occur before the convergence resolves._

--- a/tests/converge-always-test.js
+++ b/tests/converge-always-test.js
@@ -21,6 +21,13 @@ describe('BigTest Convergence - always', () => {
     }
   });
 
+  it('returns a thennable function', () => {
+    expect(test(5)).to.be.a('function');
+    expect(test(5)).to.have.property('then').that.is.a('function');
+    expect(test(5)()).to.be.an.instanceof(Promise);
+    expect(test(5).then(() => {})).to.be.an.instanceof(Promise);
+  });
+
   it('resolves if the assertion does not fail throughout the timeout', async () => {
     let start = Date.now();
     await expect(test(5)).to.be.fulfilled;

--- a/tests/converge-when-test.js
+++ b/tests/converge-when-test.js
@@ -21,6 +21,13 @@ describe('BigTest Convergence - when', () => {
     }
   });
 
+  it('returns a thennable function', () => {
+    expect(test(0)).to.be.a('function');
+    expect(test(0)).to.have.property('then').that.is.a('function');
+    expect(test(0)()).to.be.an.instanceof(Promise);
+    expect(test(0).then(() => {})).to.be.an.instanceof(Promise);
+  });
+
   it('resolves when the assertion passes within the timeout', async () => {
     timeout = setTimeout(() => total = 5, 30);
 


### PR DESCRIPTION
## Purpose

Currently, the `when` and `always` helpers are invoked immediately and return promises that can be awaited on. This is perfect for quickly converging on a state within an async function like so:

```js
async function doSomethingWhenReady() {
  await when(() => foo.isReady);
  await doSomething();
}
```

However, especially in testing frameworks, there is a need for a convergent callback helper to be able to be used for pure convergent tests.

```js
test('does something async', when(() => {
  expect(something).to.have.happened;
}));
```

## Approach

The same approach used to make the Convergence class thennable can be used to make functions thennable as well. The thennable function defines a `then` method that will invoke itself and call `then` on the subsequent resulting promise.

This enables the callback syntax while still preserving the `await` or `.then` syntax.

This also has the unintended benefit of making `when` and `always` assertions portable since they are no longer immediately invoked.

```js
let fooBar = when(() => foo === 'bar');

await fooBar;
fooBar.then(...);
test('foo', fooBar);
```

I also added a note to the readme about testing framework timeouts since this is the primary use-case for convergent callbacks.