### PR TITLE
Change trailing always to not override provided timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- trailing `always` assertions on Convergence instances default to
+  remaining time instead of always using remaining time
+
 ## [1.0.0] - 2018-09-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -165,10 +165,9 @@ converge.always(() => total === 5)
 ```
 
 When a convergence added with `.always()` is last in the queue, it
-will be given the remaining total timeout to converge on its assertion
-always passing. When it _is not_ last in the queue, `timeout` is used
-instead. By default, `timeout` will be a tenth of the total timeout
-or `20ms` (whichever is greater).
+will default to the remaining timeout to converge on its assertion
+always passing. When it _is not_ last in the queue, `timeout` defaults
+to one-tenth of the total timeout or `20ms` (whichever is greater).
 
 ``` javascript
 converge
@@ -176,15 +175,14 @@ converge
   .always(() => total === 5)
 
 converge
-  // will use the 500ms timeout instead
+  // waits 500ms
   .always(() => total === 5, 500)
-  .when(() => total === 10)
 
-new Convergence(2000)
-  // defaults to 200ms
+converge
+  .timeout(2000)
+  // defaults to 200ms (one-tenth 2000ms)
   .always(() => total === 5)
-  // this counts as part of the queue
-  .do(() => console.log(total))
+  .when(() => total === 10)
 ```
 
 **`.do(exec)`**

--- a/src/convergence.js
+++ b/src/convergence.js
@@ -172,10 +172,20 @@ class Convergence {
    * ```
    *
    * When an always assertion is encountered at the end of a
-   * convergence, it is given the remaining timeout of the current
-   * running instance. When it is not at the end, the provided `timeout`
-   * is used instead. It has a minimum of `20ms`, and defaults to
-   * one-tenth of the total timeout if not provided.
+   * convergence, the timeout defaults to the remaining time for the
+   * current running instance; minumum `20ms`. When not at the ned of
+   * a convergence, it defaults to one-tenth of the total timeout.
+   *
+   * ``` javascript
+   * let convergeFooThenBar = new Convergence(1000)
+   * // would continue after `foo` remains `'foo'` for at least 100ms
+   *   .always(() => foo === 'foo')
+   * // then have any time remaining to converge on `foo` being `'bar'`
+   *   .when(() => foo === 'bar')
+   * ```
+   *
+   * Given a timeout, it is capped at the remaining timeout for the
+   * current running instance.
    *
    * ``` javascript
    * let convergeFooThenBar = new Convergence(100)
@@ -183,11 +193,13 @@ class Convergence {
    *   .always(() => foo === 'foo', 50)
    * // then have 50ms remaining to converge on `foo` being `'bar'`
    *   .when(() => foo === 'bar')
+   * // and a maximum of ~50ms to converge on it remaining `bar`
+   *   .always(() => foo === 'bar', 100)
    * ```
    *
    * @param {Function} assertion - The assertion to converge on
-   * @param {Number} [timeout] - The timeout to use when not run at
-   * then end of the convergence
+   * @param {Number} [timeout] - The timeout to use, capped at the
+   * remaining timeout.
    * @returns {Convergence} A new convergence instance
    */
   always(assertion, timeout) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,13 +80,13 @@ export function runAssertion(subject, arg, stats) {
   let assertion = subject.assertion.bind(this, arg);
   let converge = subject.always ? always : when;
 
-  // the last always uses the remaining timeout
-  if (subject.always && !subject.last) {
-    // timeout needs to be smaller than the total timeout
+  // always defaults to one-tenth or the remaining timeout
+  if (subject.always) {
     if (subject.timeout) {
+      // ensure the timeout is shorter than the remaining
       timeout = Math.min(timeout, subject.timeout);
-      // default the timeout to one-tenth the total, or 20ms min
-    } else {
+    } else if (!subject.last) {
+      // default to one-tenth the total, minimum 20ms
       timeout = Math.max(stats.timeout / 10, 20);
     }
   }

--- a/tests/convergence-test.js
+++ b/tests/convergence-test.js
@@ -311,7 +311,7 @@ describe('BigTest Convergence', () => {
         total = 5;
         assertion = converge.always(() => {
           expect(total).to.equal(5);
-        }, 50);
+        });
       });
 
       it('retains the instance context', () => {
@@ -344,14 +344,14 @@ describe('BigTest Convergence', () => {
         expect(converge.always(() => Promise.resolve()).run()).to.be.rejectedWith(/promise/);
       });
 
-      describe('with additional chaining', () => {
+      describe('with a timeout', () => {
         beforeEach(() => {
-          assertion = assertion
-            .do(() => total = 10)
-            .when(() => expect(total).to.equal(10));
+          assertion = converge.always(() => {
+            expect(total).to.equal(5);
+          }, 50);
         });
 
-        it('resolves after at least 50ms', async () => {
+        it('resolves after the 50ms timeout', async () => {
           let start = Date.now();
           await expect(assertion.run()).to.be.fulfilled;
           expect(Date.now() - start).to.be.within(50, 70);
@@ -363,6 +363,24 @@ describe('BigTest Convergence', () => {
           let start = Date.now();
           await expect(assertion.run()).to.be.rejected;
           expect(Date.now() - start).to.be.within(30, 50);
+        });
+      });
+
+      describe('with additional chaining', () => {
+        beforeEach(() => {
+          assertion = assertion.do(() => {});
+        });
+
+        it('resolves after one-tenth the total timeout', async () => {
+          let start = Date.now();
+          await expect(assertion.timeout(1000).run()).to.be.fulfilled;
+          expect(Date.now() - start).to.be.within(100, 120);
+        });
+
+        it('resolves after at minumum 20ms', async () => {
+          let start = Date.now();
+          await expect(assertion.run()).to.be.fulfilled;
+          expect(Date.now() - start).to.be.within(20, 40);
         });
       });
     });


### PR DESCRIPTION
## Purpose

When `#always` is the last assertion in a Convergence's queue, it is always given the remaining timeout to converge on. This should be opt-in as to not cause confusion when providing your own timeout.

```js
// will always converge after 2000ms
new Convergence()
  .always(() => foo === 'bar', 100);
```

## Approach

We can _default_ the timeout to be the remaining time instead. This also makes the usage a bit simpler, since it will default to either one-tenth the timeout or the remaining timeout if last in the queue.

```js
// will converge after 50ms
new Convergence()
  .always(() => foo === 'bar', 50);

// will converge after 1000ms
new Convergence(1000)
  .always(() => foo === 'bar');

new Convergence(1000)
// will continue after 100ms
  .always(() => foo === 'bar')
// will have 900ms remaining to converge
  .when(() => foo === 'baz');
```