### PR TITLE
Let convergence queue retain previous value when returning undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- queued functions retain the previous value when returning undefined
+
 ### Changed
 
 - trailing `always` assertions on Convergence instances default to

--- a/src/convergence.js
+++ b/src/convergence.js
@@ -217,7 +217,8 @@ class Convergence {
    * queue. When a running convergence instance encounters a callback,
    * it will be invoked with the value returned from the last function
    * in the queue. The resulting return value will also be provided to
-   * the following function in the queue.
+   * the following function in the queue. If the return value is
+   * undefined, the previous return value will be retained.
    *
    * ``` javascript
    * new Convergence()
@@ -226,21 +227,19 @@ class Convergence {
    *     let n = Math.ceil(Math.random() * 100)
    *     return !(n % 2) && n
    *   })
-   *   // logs the number and continues
+   *   // multiplies the even number by another random number
    *   .do((even) => {
-   *     console.log('random even number between 1 and 100', even)
-   *     return even
+   *     return even * Math.ceil(Math.random() * 100)
+   *   })
+   *   // does not return, the previous value will be retained
+   *   .do((rand) => {
+   *     console.log('even number times random number = ', rand);
    *   })
    *   // asserts that any number times an even number is even
-   *   .always((even) => {
-   *     let n = Math.ceil(Math.random() * 100)
-   *     let rand = n * even
-   *     return !(rand % 2) && rand
+   *   .always((rand) => {
+   *     let rand = Math.ceil(Math.random() * 100);
+   *     return !(rand % 2)
    *   }, 100)
-   *   // after 100ms logs the new random even number
-   *   .do((even) => {
-   *     console.log('new random even number', even)
-   *   })
    * ```
    *
    * When a promise is returned from a callback, the convergence will
@@ -379,7 +378,7 @@ class Convergence {
         subject = Object.assign({ last: true }, subject);
       }
 
-      return promise.then((ret) => {
+      return promise.then(ret => {
         if (subject.assertion) {
           return runAssertion.call(this, subject, ret, stats);
         } else if (subject.callback) {

--- a/tests/convergence-test.js
+++ b/tests/convergence-test.js
@@ -181,7 +181,7 @@ describe('BigTest Convergence', () => {
         expect(converge._queue).to.have.lengthOf(0);
       });
 
-      it('adds to a new queue with an `exec` property', () => {
+      it('adds to a new queue with a `callback` property', () => {
         let fn = () => {};
 
         callback = callback.do(fn);
@@ -578,6 +578,29 @@ describe('BigTest Convergence', () => {
 
         await expect(assertion.run()).to.be.fulfilled;
         expect(arr).to.deep.equal(['first', 'second']);
+      });
+
+      it('curries previous return values through the stack', async () => {
+        await expect(
+          converge
+            .when(() => true)
+            .do(foo => !foo)
+            .always(foo => foo.toString())
+            // undefined returns curry the value
+            .when(foo => {
+              expect(foo).to.equal('false');
+            })
+            .do(foo => {
+              expect(foo).to.equal('false');
+            })
+            .always(foo => {
+              expect(foo).to.equal('false');
+              return null;
+            })
+            .do(foo => {
+              expect(foo).to.be.null;
+            })
+        ).to.be.fulfilled;
       });
     });
   });


### PR DESCRIPTION
## Purpose

As per issue #6, it might sometimes be expected that `#do()` does not interrupt the flow of the value between functions in the convergence queue.

This would be especially helpful in `@bigtest/interactor` validations where we can make assertions about an element before performing an interaction with it.

## Approach

When a function in the convergence queue returns `undefined`, the previous return value is curried to the next function in the queue. The value may still be modified by returning a different value, or suppressed by returning `null`.

The curried value is handled by the `collectStats` helper which returns `stats.value`. By adding another argument, we can return the previous value when `stats.value` is undefined.

All existing tests still pass, and a test was added for functions in the queue which return undefined