### PR TITLE
Add TypeScript Definitions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,14 @@ jobs:
             - convergence/dist
             - convergence/docs
 
+  check-types:
+    <<: *defaults
+    steps:
+      - *attach_workspace
+      - run:
+          name: Check TypeScript definition
+          command: yarn check-types
+
   test:
     <<: *defaults
     steps:
@@ -91,6 +99,9 @@ workflows:
           requires:
             - install
       - test:
+          requires:
+            - install
+      - check-types:
           requires:
             - install
       - deploy:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "docs": "bigtest-docs",
     "lint": "eslint --ignore-path .gitignore ./",
     "postpublish": "bigtest-tag-version",
-    "test": "mocha --opts ./tests/mocha.opts ./tests"
+    "test": "mocha --opts ./tests/mocha.opts ./tests",
+    "check-types": "tsc"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -35,6 +36,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "mocha": "^4.0.1",
     "rollup": "^0.53.0",
-    "rollup-plugin-babel": "^4.0.0"
+    "rollup-plugin-babel": "^4.0.0",
+    "typescript": "^3.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "https://github.com/bigtestjs/convergence",
   "main": "dist/umd/index.js",
   "module": "dist/esm/index.js",
+  "types": "types/index.d.ts",
   "files": [
     "dist",
     "docs",

--- a/tests/definition-test.ts
+++ b/tests/definition-test.ts
@@ -1,0 +1,33 @@
+import Convergence, { when, always, isConvergence } from '@bigtest/convergence';
+
+when<string>(() => 'hello world').then(v => v.value.toUpperCase());
+when(() => true).then(() => {});
+
+always(() => true);
+always(() => 'hello world').then(v => v.value.toUpperCase());
+
+isConvergence('hello world');
+
+let c = new Convergence(4000);
+
+c.timeout().toFixed();
+c.timeout(2000)
+  .run()
+  .then(() => {});
+
+c.when(() => 'hello world')
+  .run()
+  .then(v => v.value.toUpperCase());
+
+c.always(() => 'hello world')
+  .run()
+  .then(v => v.value.toUpperCase());
+  
+c.when(() => 'hello world')
+  .do(message => new Promise(resolve => resolve(message)))
+  .then();
+
+// TODO: include case when then takes an argument
+
+c.append(new Convergence(2000)).run().then(() => {});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,18 @@
 {
   "compilerOptions": {
-    "strict": true
-  }
+    "strict": true,
+    "lib": ["es6"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "baseUrl": "./",
+    "typeRoots": ["./types"],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": []
+  },
+  "include": [
+    "src"
+  ],
+  "files": ["types/index.d.ts", "tests/definition-test.ts"]
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,31 +1,120 @@
-export declare function when<T = undefined>(assertion: () => T): PromiseLike<Stats<T>>;
-export declare function always<T = undefined>(assertion: () => T, timeout?: number): PromiseLike<Stats<T>>;
-export declare function isConvergence(obj: any): boolean
-export default Convergence;
+// Type definitions for @bigtest
+// Project: https://github.com/bigtestjs/interactor
+// Definitions by: Wil Wilsman<hello@wilwilsman.com>, Taras Mankovski <taras@frontside.io>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare class Convergence<R = undefined> implements PromiseLike<R> {
-  static isConvergence(obj: any): boolean;
-  constructor(timeout: number);
-  timeout(): number;
-  timeout(timeout: number): Convergence<R>;
-  when(assertion: (value: R) => undefined): Convergence<R>;
-  when<U>(assertion: (value: R) => U): Convergence<U>;
-  always(assertion: (value: R) => undefined, timeout?: number): Convergence<R>;
-  always<U>(assertion: (value: R) => U, timeout?: number): Convergence<U>;
-  do(callback: (value: R) => undefined): Convergence<R>;
-  do<U>(callback: (value: R) => U | PromiseLike<U> | Convergence<U>): Convergence<U>;
-  append<U = undefined>(convergence: Convergence<U>): Convergence<U>;
-  run(): Promise<Stats<R>>;
-  then(): Promise<R>;
-}
+declare module "@bigtest/convergence" {
+  /**
+   * Converges on an assertion by resolving when the given assertion
+   * passes _within_ the timeout period. The assertion will run once
+   * every 10ms and is considered to be passing when it does not error
+   * or return false. If the assertion never passes within the timeout
+   * period, then the promise will reject as soon as it can with the
+   * last error it recieved.
+   */
+  export function when<T = undefined>(assertion: () => T): PromiseLike<Stats<T>>;
 
-declare interface Stats<T = void> {
-  start: number,
-  runs: number,
-  end: number,
-  elapsed: number,
-  always?: boolean,
-  timeout?: number,
-  queue?: Array<Stats>,
-  value: T
+  /**
+   * Converges on an assertion by resolving when the given assertion
+   * passes _throughout_ the timeout period. The assertion will run once
+   * every 10ms and is considered to be passing when it does not error
+   * or return false. If the assertion does not pass consistently
+   * throughout the entire timeout period, it will reject the very first
+   * time it encounters a failure.
+   */
+  export function always<T = undefined>(assertion: () => T, timeout?: number): PromiseLike<Stats<T>>;
+
+  /**
+   * Returns `true` if the object has common convergence properties of 
+   * the correct type.
+   */
+  export function isConvergence(obj: any): boolean
+
+  /**
+   * A convergence is an assertion that is satisfied when state is matched 
+   * or fails if it's not able to match the state before the timeout is reached.
+   */
+  export default class Convergence<R = undefined> implements PromiseLike<R> {
+    static isConvergence(obj: any): boolean;
+    /**
+     * The constructor actually takes two params, `options` and
+     * `previous`. Publicly, `options` is `timeout`, but internally, new
+     * instances receive new `options` in addition to the `previous`
+     * instance. This allows things that extend convergences to still be
+     * immutable, but requires that they have deeper knowledge of the
+     * internal API.
+     */
+    constructor(timeout: number);
+
+    /**
+     * Returns the current timeout for this instance.
+     */
+    timeout(): number;
+
+    /**
+     * Returns a new convergence instance with the given timeout,
+     * inheriting the current instance's assertions.
+     */
+    timeout<R>(timeout: number): Convergence<R>;
+
+    /**
+     * Returns a new convergence instance with an additional assertion.
+     * This assertion is run repeatedly until it passes within the
+     * timeout. If the assertion does not pass within the timeout, the
+     * convergence will fail.
+     */    
+    when(assertion: (value: R) => undefined): Convergence<R>;
+    when<U>(assertion: (value: R) => U): Convergence<U>;
+
+    /**
+     * Returns a new convergence instance with an additional assertion.
+     * This assertion is run repeatedly to ensure it passes throughout
+     * the timeout. If the assertion fails at any point during the
+     * timeout, the convergence will fail.
+     */
+    always(assertion: (value: R) => undefined, timeout?: number): Convergence<R>;
+    always<U>(assertion: (value: R) => U, timeout?: number): Convergence<U>;
+
+    /**
+     * Returns a new convergence instance with a callback added to its
+     * queue. When a running convergence instance encounters a callback,
+     * it will be invoked with the value returned from the last function
+     * in the queue. The resulting return value will also be provided to
+     * the following function in the queue. If the return value is
+     * undefined, the previous return value will be retained.
+     */
+    do(callback: (value: R) => undefined): Convergence<R>;
+    do<U>(callback: (value: R) => U | PromiseLike<U> | Convergence<U>): Convergence<U>;
+
+    /**
+     * Appends another convergence's queue to this convergence's queue
+     * to allow composing different convergences together.
+     */
+    append<U = undefined>(convergence: Convergence<U>): Convergence<U>;
+
+    /**
+     * Runs the current convergence instance, returning a promise that
+     * will resolve after all assertions have converged, or reject when
+     * any of them fail.
+     */
+    run(): Promise<Stats<R>>;
+
+    /**
+     * By being thennable we can enable the usage of async/await syntax
+     * with convergences. This allows us to naturally chain convergences
+     * without calling `#run()`.
+     */
+    then<R>(): Promise<R>;
+  }
+
+  export interface Stats<T = void> {
+    start: number,
+    runs: number,
+    end: number,
+    elapsed: number,
+    always?: boolean,
+    timeout?: number,
+    queue?: Array<Stats>,
+    value: T
+  }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,31 @@
+export declare function when<T = undefined>(assertion: () => T): PromiseLike<Stats<T>>;
+export declare function always<T = undefined>(assertion: () => T, timeout?: number): PromiseLike<Stats<T>>;
+export declare function isConvergence(obj: any): boolean
+export default Convergence;
+
+declare class Convergence<R = undefined> implements PromiseLike<R> {
+  static isConvergence(obj: any): boolean;
+  constructor(timeout: number);
+  timeout(): number;
+  timeout(timeout: number): Convergence<R>;
+  when(assertion: (value: R) => undefined): Convergence<R>;
+  when<U>(assertion: (value: R) => U): Convergence<U>;
+  always(assertion: (value: R) => undefined, timeout?: number): Convergence<R>;
+  always<U>(assertion: (value: R) => U, timeout?: number): Convergence<U>;
+  do(callback: (value: R) => undefined): Convergence<R>;
+  do<U>(callback: (value: R) => U | PromiseLike<U> | Convergence<U>): Convergence<U>;
+  append<U = undefined>(convergence: Convergence<U>): Convergence<U>;
+  run(): Promise<Stats<R>>;
+  then(): Promise<R>;
+}
+
+declare interface Stats<T = void> {
+  start: number,
+  runs: number,
+  end: number,
+  elapsed: number,
+  always?: boolean,
+  timeout?: number,
+  queue?: Array<Stats>,
+  value: T
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2218,6 +2218,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.1.tgz#6de14e1db4b8a006ac535e482c8ba018c55f750b"
+  integrity sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA==
+
 typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"


### PR DESCRIPTION
## Purpose

TypeScript is a very popular technology in the JavaScript community. Many teams that use automated testing also use TypeScript. Having TypeScript definitions will make it easier for users who  use TypeScript learn the APIs that BigTest exposes.

## Method

This PR adds a definition file that describes the `@bigtest/convergence` module and a test to verify that these definitions work correctly. The definitions are verified automatically as a workflow in CircleCI. The type definition tests only run on CI, but can be executed from CLI by running `yarn check-types` 